### PR TITLE
Pylint update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.eggs
 /.env
 /.ropeproject
+/.idea
 /build
 /dist
 /libs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pylama          >= 6.3.3
-pylint          == 1.5.4
+pylint          == 1.5.5

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     packages=find_packages(),
     package_data={'pylama_pylint': ['pylint.rc']},
     install_requires=[
-        l for l in _read('requirements.txt').split('\n')
+        l.replace('==', '>=') for l in _read('requirements.txt').split('\n')
         if l and not l.startswith('#')],
     tests_require=['pytest'],
     cmdclass={'test': __PyTest},


### PR DESCRIPTION
Reason is actually this travis built triggered by require.io on one of mine packages:

https://travis-ci.org/ClearcodeHQ/matchbox/jobs/122907317

There's a newer pylint, but pylama_pylint sticks to specified version.
Incorporating the change from https://github.com/klen/pylama/pull/60 should allow to install never pylint, and keeping certain version defined in requirements.txt will allow to do something I have for the matchbox package above - to trigger builds with new version of a dependency, and do modifications afterwards, if tests fails, merge otherwise.
