### PR TITLE
Do not clear astroid cache

### DIFF
--- a/pylama_pylint/main.py
+++ b/pylama_pylint/main.py
@@ -2,7 +2,6 @@
 import logging
 from os import path as op, environ
 
-from astroid import MANAGER
 from pylama.lint import Linter as BaseLinter
 from pylint.lint import Run
 from pylint.reporters import BaseReporter
@@ -27,8 +26,6 @@ class Linter(BaseLinter):
         :return list: List of errors.
         """
         logger.debug('Start pylint')
-
-        MANAGER.astroid_cache.clear()
 
         class Reporter(BaseReporter):
 


### PR DESCRIPTION
It is not needed unless the source files change (they don't when running pylama once in its own process) and
regenerating the cache for each module checked by pylama_pylint can take a long time.
